### PR TITLE
log video v5

### DIFF
--- a/examples/advection
+++ b/examples/advection
@@ -3,9 +3,11 @@
 from nutils import *
 
 
-def makeplots( domain, geom, u ):
+def makeplots( domain, geom, u, plt ):
   xp, up = domain.elem_eval( [ geom, u ], ischeme='bezier9', separate=True )
-  with plot.PyPlot( 'solution', ndigits=4 ) as plt:
+  if plt is True:
+    plt = plot.PyPlot( 'solution', ndigits=4 )
+  with plt:
     plt.mesh( xp, up )
     if domain.ndims == 2:
       plt.gca().set_aspect( 'equal' )
@@ -15,7 +17,7 @@ def makeplots( domain, geom, u ):
       plt.ylim( -.1, 1.1 )
 
 
-def main( nelems=40, degree=1, timestep=.01, tol=1e-10, cg=False, alpha=.5, ndims=1, maxiter=-1, plots=True, tau=1 ):
+def main( nelems=40, degree=1, timestep=.01, tol=1e-10, cg=False, alpha=.5, ndims=1, maxiter=-1, plt=True, tau=1 ):
   
   if ndims == 1:
     domain, geom = mesh.rectilinear( [numpy.linspace(0,1,nelems+1)], periodic=[0] )
@@ -31,6 +33,9 @@ def main( nelems=40, degree=1, timestep=.01, tol=1e-10, cg=False, alpha=.5, ndim
     u = function.exp( -( ( ( geom - center0 ) / width )**2 ).sum(-1) )
   else:
     raise Exception( 'not supported: ndims=%s' % ndims )
+
+  if plt == 'video':
+    plt = plot.PyPlotVideo( 'solution' )
 
   basis = domain.basis( 'spline' if cg else 'discont', degree=degree )
   lhs = domain.project( u, onto=basis, geometry=geom, ptype='convolute', ischeme='gauss5' )
@@ -49,8 +54,8 @@ def main( nelems=40, degree=1, timestep=.01, tol=1e-10, cg=False, alpha=.5, ndim
 
   for itime in log.count( 'timestep' ):
 
-    if plots:
-      makeplots( domain, geom, basis.dot(lhs) )
+    if plt:
+      makeplots( domain, geom, basis.dot(lhs), plt )
 
     matrix = matrix1 + tau * matrix2
     rhs = matrix1.matvec(lhs) + (tau-1) * matrix2.matvec(lhs)
@@ -64,20 +69,20 @@ def main( nelems=40, degree=1, timestep=.01, tol=1e-10, cg=False, alpha=.5, ndim
 
 def unittest():
 
-  retvals = main( ndims=1, nelems=10, timestep=.01, degree=1, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=1, nelems=10, timestep=.01, degree=1, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNolz9sNBSEIBNB2dhNIGF5iQbf/Fi6wXzOKxiPocUK89Dwh7j8uOhX3x5fYxWRLIvBjCBnybvGTPQKI
     1VO/Zhmzp+RSfdzIS89kSMWX2LxAX+lnj9okl2e/HMTwU1OOVU+SoOqTLageHOJ7RQbZYM9aLyNNtzhu
     DRhem5YZy2W0/GvWdb2A5ZYwqeXAlgsJXWbN2qlxskxYfN4AMEykLDd0PtrM/lFsCYkYb2/o5EvvH/rr
     Tcs=''' )
 
-  retvals = main( ndims=1, nelems=10, timestep=.01, degree=1, cg=False, maxiter=2, plots=False, tau=.5 )
+  retvals = main( ndims=1, nelems=10, timestep=.01, degree=1, cg=False, maxiter=2, plt=False, tau=.5 )
   assert debug.checkdata( retvals, '''
     eNotj1sOBCEIBK8zk2Bi8xIONPe/wgLuV5cB7RL0KMFeeh5mw7eCkL6/lbQAu5Bu/NWRzOOCukYB0+Kj
     8ifetQ4hCSkQ0tjZadg+uSGdgN+MrLlW0e73G7gnRod70yu75tBS5AUJOy1Zwrw5G1fo8SvMGGGrhjLZ
     5GE2vouTcUmO2AjDNwZsy9TXrfEsnfHL6AUlTdar5+oDxubtiTzRqdo/9to4bgMC5xYGX/GX3h8vo035''' )
   
-  retvals = main( ndims=1, nelems=10, timestep=.01, degree=2, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=1, nelems=10, timestep=.01, degree=2, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNotkdGtxTAIQ9dpJSKBgQAD3f1XeEBff3xKaMGO0GMk/tLzyE3+nSR4tBYdQS1IP6s3/HeE6aSzNQmF
     IhaESxaOe2kTyBK2ELwVpaM3sASLPlNSKawa8yririq+c9UcTfce3Zsar557sxudPIDRAnfjpWNmNaAp
@@ -85,7 +90,7 @@ def unittest():
     EFJRS3IngDHma7h32fdyia3v+l2v+YlRYi6pAzDHNprPpXinLTzacyMHJD0mAERtED1t9r7kPg3Zo6Gb
     TMgsM0kgY5299P4BmUR0Hw==''' )
 
-  retvals = main( ndims=2, nelems=4, timestep=.01, degree=1, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=2, nelems=4, timestep=.01, degree=1, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNpNU1uOLSAI285Moom8YUGz/y1cKOck96uKSJFWOj96yH7Pz88lF/u79M7VIu0VnesU/nfrXM5ILIQs
     ZsFFtjmszH83zi2ba3luEuWemb7J4kNeNddKy3FEzwkLYZ4UaVqmPbuRzoix05uSXFaDFPaGi+jloD7q
@@ -96,7 +101,7 @@ def unittest():
     ltR9nhVj+eI14DzLjrNDMMJgWxCfUtqGHUHHCGM4PfZ0hX0CQUhmcC0MhIoWaP5dt8APRmCZN8xnw4ea
     wDrxWhgsQ/L9AlJgpLWESX06ytxOGEzEUdvRotb8UDtMsYzkO8VSTK3/Pb7i7/n9BwRU7UU=''' )
 
-  retvals = main( ndims=2, nelems=3, timestep=.01, degree=2, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=2, nelems=3, timestep=.01, degree=2, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNo1VMmNIDEITGdGsiVuTECTfwoLRe+jVQZjzqL5/Nhh/z0/P5fZ7e8ynf4q96QshZNG9mUddYtBZ4Nc
     QY3vsJj/3TyiGoNcug85641hZukq2AgvnsATv5DBx17wIGrwoLF2XrIpGI1LPkxKOFwVWqeqJHuXvHdm

--- a/examples/burgers
+++ b/examples/burgers
@@ -3,16 +3,18 @@
 from nutils import *
 
 
-def makeplots( domain, geom, u ):
+def makeplots( domain, geom, u, plt ):
+  if plt is True:
+    plt = plot.PyPlot( 'solution' )
   if domain.ndims == 1:
     xp, up = domain.elem_eval( [ geom, u[0] ], ischeme='bezier9', separate=True )
-    with plot.PyPlot( 'solution' ) as plt:
+    with plt:
       plt.mesh( xp, up )
       plt.ylim( -.1, 1.1 )
   elif domain.ndims == 2:
     X, C = domain.elem_eval( [ geom, function.norm2(u) ], ischeme='bezier3', separate=True )
     xp, up = domain.elem_eval( [ geom, u ], ischeme='uniform3', separate=False )
-    with plot.PyPlot( 'solution' ) as plt:
+    with plt:
       plt.mesh( X, C, edgewidth=.1, edgecolor='w' )
       plt.clim( 0, 1 )
       plt.gca().set_aspect( 'equal' )
@@ -21,7 +23,7 @@ def makeplots( domain, geom, u ):
       plt.ylim(-1,1)
 
 
-def main( nelems=40, degree=1, timestep=.001, tol=1e-8, cg=False, alpha=.5, ndims=1, maxiter=-1, plots=True, tau=1 ):
+def main( nelems=40, degree=1, timestep=.001, tol=1e-8, cg=False, alpha=.5, ndims=1, maxiter=-1, plt=True, tau=1 ):
   
   if ndims == 1:
     domain, geom = mesh.rectilinear( [numpy.linspace(0,1,nelems+1)], periodic=[0] )
@@ -34,6 +36,9 @@ def main( nelems=40, degree=1, timestep=.001, tol=1e-8, cg=False, alpha=.5, ndim
   else:
     raise Exception( 'not supported: ndims=%s' % ndims )
 
+  if plt == 'video':
+    plt = plot.PyPlotVideo( 'solution' )
+
   basis = domain.basis( 'spline' if cg else 'discont', degree=degree ).vector( ndims )
   lhs = domain.project( u, onto=basis, geometry=geom, ptype='convolute', ischeme='gauss5' )
 
@@ -42,8 +47,8 @@ def main( nelems=40, degree=1, timestep=.001, tol=1e-8, cg=False, alpha=.5, ndim
 
   for itime in log.count( 'timestep' ):
 
-    if plots:
-      makeplots( domain, geom, basis.dot(lhs) )
+    if plt:
+      makeplots( domain, geom, basis.dot(lhs), plt )
 
     for ipicard in log.count( 'picard' ):
 
@@ -78,18 +83,18 @@ def main( nelems=40, degree=1, timestep=.001, tol=1e-8, cg=False, alpha=.5, ndim
 
 def unittest():
 
-  retvals = main( ndims=1, nelems=10, timestep=.001, degree=1, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=1, nelems=10, timestep=.001, degree=1, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNp1zlEKACEIRdHtFOigpeVbUPvfwljz24BwQOGiUjFSr1SKPHQdC7XFjQxoWxeVTzkqkPZ0xuJxKWT9
     Lx7oc3G+IBYnIjK3wBhnr4EtO1oe/FqvLy7mJ1k=''' )
 
-  retvals = main( ndims=1, nelems=10, timestep=.001, degree=2, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=1, nelems=10, timestep=.001, degree=2, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNqNj2sKAzEIhK+zC6ZkfCR6oL3/FarJtpT+aSEwo0z0E3QowU46jv6gn08w+tWYRNi36qvmrSK3aili
     xNWEOGBXG9Sg4mVUeJYCMwcA1Mw1o8g/02y1vnYn4z+I02fOyaMQUqtDrVcdLlj9XijZj1qjxAMr33j0
     WcaHZdAyOGQz30ZMUyeB3Tfz2ykHL/gP2vMJAeRHZg==''' )
 
-  retvals = main( ndims=2, nelems=4, timestep=.001, degree=1, cg=False, maxiter=2, plots=False )
+  retvals = main( ndims=2, nelems=4, timestep=.001, degree=1, cg=False, maxiter=2, plt=False )
   assert debug.checkdata( retvals, '''
     eNrtk2tqxDAMhK+zC3bx6GFbB8r9r1BbXjlJ+2d/FQoLAVl5zDfSEKSHJOgzPR7lK715ZTLTI4PGibWP
     E27PWSFHpiREdqs9eimzsvJ6r69eSOusKG30kipjipeE1jBvwJSPbDdYiIXIFn2JSVesvrZrZVV/D607

--- a/examples/cahnhilliard
+++ b/examples/cahnhilliard
@@ -4,14 +4,16 @@ from nutils import *
 
 
 @log.title
-def makeplots( domain, geom, c, mu, energies, nsteps ):
+def makeplots( domain, geom, c, mu, energies, nsteps, plt ):
 
   force = mu * c.grad(geom)
   xpnt, cpnt = domain.elem_eval( [ geom, c ], ischeme='bezier4', title='mesh', separate=True )
   xy, uv = domain.elem_eval( [ geom, force ], ischeme='uniform1', title='quiver', separate=False )
   Emix, Eiface, Ewall = numpy.array(energies).T
 
-  with plot.PyPlot( 'concentration', ndigits=4, index=len(energies) ) as plt:
+  if plt is True:
+    plt = plot.PyPlot( 'concentration', ndigits=4, index=len(energies) )
+  with plt:
     plt.mesh( xpnt, cpnt )
     plt.colorbar()
     plt.clim( -1, 1 )
@@ -33,7 +35,7 @@ def makeplots( domain, geom, c, mu, energies, nsteps ):
     plt.ylabel( 'energy' )
 
 
-def main( nelems=20, epsilon=None, timestep=.01, maxtime=1., theta=90, init='random', plot=True ):
+def main( nelems=20, epsilon=None, timestep=.01, maxtime=1., theta=90, init='random', plt=True ):
 
   mineps = 1./nelems
   nsteps = numeric.round( maxtime / timestep )
@@ -44,6 +46,9 @@ def main( nelems=20, epsilon=None, timestep=.01, maxtime=1., theta=90, init='ran
     epsilon = mineps
   elif epsilon < mineps:
     log.warning( 'epsilon under crititical threshold: %f < %f' % ( epsilon, mineps ) )
+
+  if plt == 'video':
+    plt = plot.PyPlotVideo( 'concentration' )
 
   xnodes = ynodes = numpy.linspace(0,1,nelems+1)
   domain, geom = mesh.rectilinear( [ xnodes, ynodes ] )
@@ -92,15 +97,15 @@ def main( nelems=20, epsilon=None, timestep=.01, maxtime=1., theta=90, init='ran
     c = cbasis.dot( lhs )
     mu = mubasis.dot( lhs )
 
-    if plot:
-      makeplots( domain, geom, c, mu, energies, nsteps )
+    if plt:
+      makeplots( domain, geom, c, mu, energies, nsteps, plt )
 
   return lhs, energies
 
 
 def unittest():
 
-  retvals = main( nelems=8, init='bubbles', maxtime=.1, plot=False )
+  retvals = main( nelems=8, init='bubbles', maxtime=.1, plt=False )
   assert debug.checkdata( retvals, '''
     eNptlVmSIjEMRK/TEwETlqz1QH3/K4xLGwVD9IdcwvWcmTI0PH7oAfzn8fNjrPr7pIex8VUVwa/KBPb7
     5MdTF+2r8TTfsePpG7LjhKsWgm+Lphk7JJXiFAGCom5oKjVVmsrfqa2taaxosUFsSWLRsbCQfEfW4osX

--- a/examples/cylinderflow
+++ b/examples/cylinderflow
@@ -5,7 +5,7 @@ from nutils import *
 
 
 @log.title
-def makeplots( domain, geom, velo, pres, index ):
+def makeplots( domain, geom, velo, pres, index, plts ):
 
   vort = velo.grad(geom)[1,0] - velo.grad(geom)[0,1]
   xlim = -4, 14
@@ -13,21 +13,27 @@ def makeplots( domain, geom, velo, pres, index ):
   xy, uv = domain.elem_eval( [ geom, velo ], ischeme='uniform1', separate=False )
   points, flow, pres, vort = domain.elem_eval( [ geom, function.norm2(velo), pres, vort ], ischeme='bezier5', separate=True )
 
-  with plot.PyPlot( 'flow', index=index ) as plt:
+  if plts is True:
+    plts = [ plot.PyPlot( name, index=index ) for name in [ 'flow', 'pres', 'vort' ] ]
+
+  with plts[0] as plt:
+    plt._pyplot.figure(plt._fig.number)
     plt.mesh( points, flow, triangulate='bezier' )
     plt.colorbar( orientation='horizontal' )
     plt.xlim( xlim )
     plt.ylim( ylim )
     plt.quiver( xy[:,0], xy[:,1], uv[:,0], uv[:,1] )
 
-  with plot.PyPlot( 'pres', index=index ) as plt:
+  with plts[1] as plt:
+    plt._pyplot.figure(plt._fig.number)
     plt.mesh( points, pres, triangulate='bezier' )
     plt.colorbar( orientation='horizontal' )
     plt.xlim( xlim )
     plt.ylim( ylim )
     plt.quiver( xy[:,0], xy[:,1], uv[:,0], uv[:,1] )
 
-  with plot.PyPlot( 'vort', index=index ) as plt:
+  with plts[2] as plt:
+    plt._pyplot.figure(plt._fig.number)
     plt.mesh( points, vort, triangulate='bezier' )
     plt.colorbar( orientation='horizontal' )
     plt.xlim( xlim )
@@ -35,7 +41,10 @@ def makeplots( domain, geom, velo, pres, index ):
     plt.quiver( xy[:,0], xy[:,1], uv[:,0], uv[:,1] )
 
 
-def main( nelems=24, viscosity=1e-3, density=1, tol=1e-8, rotation=0, timestep=.1, maxradius=50 ):
+def main( nelems=24, viscosity=1e-3, density=1, tol=1e-8, rotation=0, timestep=.1, maxradius=50, plt=True ):
+
+  if plt == 'video':
+    plt = [ plot.PyPlotVideo( name ) for name in [ 'flow', 'pres', 'vort' ] ]
 
   rscale = 2*numpy.pi / nelems
   melems = numpy.ceil( numpy.log(maxradius) / rscale ).astype( int )
@@ -80,7 +89,7 @@ def main( nelems=24, viscosity=1e-3, density=1, tol=1e-8, rotation=0, timestep=.
 
   stokesmat += inertmat
   for iiter in log.count( 'timestep' ):
-    makeplots( domain, geom, vbasis.dot(lhs), pbasis.dot(lhs), iiter )
+    makeplots( domain, geom, vbasis.dot(lhs), pbasis.dot(lhs), iiter, plt )
     convection = density * ( vbasis.grad(geom) * vbasis.dot(lhs) ).sum(-1)
     matrix = stokesmat + domain.integrate( function.outer( vbasis, convection ).sum(-1), ischeme='gauss9', geometry=geom )
     lhs = matrix.solve( rhs + inertmat.matvec(lhs), lhs0=lhs, constrain=cons, tol=tol, restart=9999, precon='spilu' )

--- a/nutils/log.py
+++ b/nutils/log.py
@@ -85,7 +85,7 @@ class HtmlStream( Stream ):
 
   @staticmethod
   def _path2href( match ):
-    whitelist = ['.jpg','.png','.svg','.txt'] + core.getprop( 'plot_extensions', [] )
+    whitelist = ['.jpg','.png','.svg','.txt','.mp4','.webm'] + core.getprop( 'plot_extensions', [] )
     filename = match.group(0)
     ext = match.group(1)
     return '<a href="%s">%s</a>' % (filename,filename) if ext not in whitelist \

--- a/nutils/plot.py
+++ b/nutils/plot.py
@@ -14,7 +14,7 @@ backends. At this point `matplotlib <http://matplotlib.org/>`_ and `vtk
 
 from __future__ import print_function, division
 from . import numpy, log, core, cache, _
-import os, warnings, sys
+import os, warnings, sys, subprocess
 
 
 class BasePlot( object ):
@@ -370,6 +370,110 @@ class PyPlot( BasePlot ):
 
   def vectors( self, xy, uv, **kwargs ):
     self.quiver( xy[:,0], xy[:,1], uv[:,0], uv[:,1], angles='xy', **kwargs )
+
+class PyPlotVideo( PyPlot ):
+  '''matplotlib based video generator
+
+  Video generator based on matplotlib figures.  Follows the same syntax as
+  `PyPlot`.
+
+  Parameters
+  ----------
+
+  clearfigure: bool, default: True
+    If True clears the matplotlib figure after writing each frame.
+
+  framerate: int, float, default: 24
+    Framerate in frames per second of the generated video.
+
+  videotype: str, default: 'webm' unless overriden by property ``videotype``
+    Video type of the generated video.  Note that not every video type supports
+    playback before the video has been finalized, i.e. before ``close`` has
+    been called.
+
+  Nutils properties
+  -----------------
+
+  videotype: see parameter with the same name
+
+  videoencoder: str, default: 'ffmpeg'
+    Name or path of the video encoder.  The video encoder should take the same
+    arguments as 'ffmpeg'.
+
+  Examples
+  --------
+
+  Using a ``with``-statement:
+
+    video = PyPlotVideo('video')
+    for timestep in timesteps:
+      ...
+      with video:
+        video.plot(...)
+        video.title('frame {:04d}'.format(video.frame))
+    video.close()
+
+  Using ``saveframe``:
+
+    video = PyPlotVideo('video')
+    for timestep in timesteps:
+      ...
+      video.plot(...)
+      video.title('frame {:04d}'.format(video.frame))
+      video.saveframe()
+    video.close()
+  '''
+
+  def __init__(self, name, videotype=None, clearfigure=True, framerate=24):
+    'constructor'
+
+    PyPlot.__init__( self, ndigits=0 )
+
+    self.frame = 0
+    self._clearfigure = clearfigure
+    if videotype is None:
+      videotype = core.getprop( 'videotype', 'webm' )
+    self._encoder = subprocess.Popen([
+        core.getprop( 'videoencoder', 'ffmpeg' ),
+        '-loglevel', 'quiet',
+        '-probesize', '1k',
+        '-analyzeduration', '1',
+        '-y',
+        '-f', 'image2pipe',
+        '-vcodec', 'png',
+        '-r', str(framerate),
+        '-i', '-',
+        '-b:v', '1500k',
+        self.getpath( name, None, videotype ),
+      ], stdin=subprocess.PIPE )
+
+  def __enter__( self ):
+    'enter with block'
+
+    return self
+
+  def __exit__( self, exc_type, exc_value, exc_tb ):
+    'exit with block'
+
+    if not exc_type:
+      self.saveframe()
+
+  def saveframe( self ):
+    'add a video frame'
+
+    assert self._fig, 'video is closed'
+    self.savefig( self._encoder.stdin, format='png' )
+    if self._clearfigure:
+      self._fig.clear()
+
+  def close( self ):
+    'finalize video'
+
+    if not self._encoder:
+      return # already closed
+    self._encoder.stdin.close()
+    self._encoder = None
+    PyPlot.close( self )
 
 class DataFile( BasePlot ):
   """data file"""

--- a/nutils/util.py
+++ b/nutils/util.py
@@ -534,7 +534,11 @@ def run( *functions ):
     if core.getprop( 'profile' ):
       prof.disable()
 
-    if hasattr( os, 'wait' ):
+    if hasattr( os, 'wait' ) and frames is None:
+      # clear exception info, helps closing subprocesses that otherwise cause a
+      # deadlock when calling `os.wait` below
+      sys.exc_clear()
+      exc = None
       try: # wait for child processes to die
         while True:
           pid, status = os.wait()


### PR DESCRIPTION
See the docstring of `PyPlotVideo` for an explanation. I use the numpy format for the docstrings, but with an indentation of two spaces instead of four.

Compared with #76 child processes are now properly closed when the user kills the simulation (13d873c) and time-dependent examples can generate videos when running with `--plt=video` (625e1e6).