### PR TITLE
Spsolve

### DIFF
--- a/examples/adaptivity
+++ b/examples/adaptivity
@@ -107,7 +107,7 @@ def main( degree=1, solvetol=1e-10, circle=False, uniform=False, basistype='std'
 
 def unittest():
 
-  retvals = main( degree=1, solvetol=1e-10, circle=False, uniform=False, basistype='std', nrefine=2, withplots=False )
+  retvals = main( degree=1, solvetol=0, circle=False, uniform=False, basistype='std', nrefine=2, withplots=False )
   assert debug.checkdata( retvals, '''
     eNqNVVmuJDkIvM57UuaIfTlQ3/8KjcF21fy1VJIpzBJAmMTnRx7U3+fnxyjzzyuPMNM6iRD6P0Gd8byl
     6Iu3LLiF42LhrRBPb9cS2gBZ9M9r5Ssp4+vj8lrYCOqGbcOAOhqlMXaTSSRIMV4GDeoNkw0GcYw1Y2wC
@@ -124,7 +124,7 @@ def unittest():
     zBtCpe8L0sWz/l5vdrmOAm0mXdMcjx50dKtrMfslFOxl8Wp9ylqi/TgsaDYLYp7FVF+lw7/f5/cvNmnD
     XQ==''' )
 
-  retvals = main( degree=2, solvetol=1e-10, circle=False, uniform=False, basistype='spline', nrefine=1, withplots=False )
+  retvals = main( degree=2, solvetol=0, circle=False, uniform=False, basistype='spline', nrefine=1, withplots=False )
   assert debug.checkdata( retvals, '''
     eNqNVFmuHDEIvM4bqR2ZzcCBcv8rhM2tiZSPSCOZwVBQBW54fvgB+Tw/P4f2/r34EWLOk9ApTwA4ea7X
     uDfrhq6be0TKIWJeGAxYGNj3gWGDwccaQ7Q9N1cRK+dAR5D3CeBdDJgHw0+jHsT23FyDXR3qYLCc5uLW
@@ -138,7 +138,7 @@ def unittest():
     hnzo0attjOdyVlGv5muoUdzmv+2ZSdPM4jwurs0fFjZNoNrdCrzrTLKbtxzBQdt+H5/k/Hq/YsxFADw/
     QPVGZdCO5qcoJ6V6Za27eJDq3w/yn7/P8/kDV7pq1w==''' )
 
-  retvals = main( degree=1, solvetol=1e-10, circle=True, uniform=False, basistype='std', nrefine=1, withplots=False )
+  retvals = main( degree=1, solvetol=0, circle=True, uniform=False, basistype='std', nrefine=1, withplots=False )
   assert debug.checkdata( retvals, '''
     eNqNU1tuAzEIvE4irSvejwP1/leoAW/atD+NLHkCDAyYxeshF+rzejyMMj+XXMLMdRMh1b0UTT4X4rVe
     pjtm3SQLG7K7NFkUO4BMdqRtIDkU8bThHo6bNEdlHBQhEwCOw83DVaXheqeVK0y6jql510eOU7e4usuh

--- a/examples/drivencavity
+++ b/examples/drivencavity
@@ -84,7 +84,7 @@ def main( nelems=12, viscosity=1e-3, density=1, degree=2, warp=False, withplots=
 
 def unittest():
 
-  retvals = main( nelems=4, viscosity=1e-3, degree=1, warp=False, tol=1e-15, maxiter=1, withplots=False )
+  retvals = main( nelems=4, viscosity=1e-3, degree=1, warp=False, tol=0, maxiter=1, withplots=False )
   assert debug.checkdata( retvals, '''
     eNrFkl1uxCAMhK+zK0Hl8S8+UO5/hYKdbJ8q9a0SEpE9DJ+HYLx0wN7j9aKv0cvd45oxnIiu6ePTwF3I
     Pzd+tfr3tSeexsuuaUOD5OwTknxNHa4SpwA6Ah2T8/BvBUO0K2vR+eAgnF0TqxrKmi3NbCk8S4q0ktiK
@@ -92,7 +92,7 @@ def unittest():
     rR9gQwfmvFrykMI7qL2XAqFaXORVd0rvvkXXubhnhPABnDu+ukxcVjtA+0Q77QyiiVOWNwWoUtnD5i2V
     O0/SMpU7npmJ+hH3m7QrtHmygxUW6oCtAq4/5f0NMWaoJA==''' )
 
-  retvals = main( nelems=4, viscosity=1e-3, degree=2, warp=False, tol=1e-15, maxiter=1, withplots=False )
+  retvals = main( nelems=4, viscosity=1e-3, degree=2, warp=False, tol=0, maxiter=1, withplots=False )
   assert debug.checkdata( retvals, '''
     eNrVU1mK3UAMvM4bsIP25UBz/yvEUvUbmAmE/AYMaloqqark5utlF/vH9XrRr+vrYyL6vOMKR/yWO3ed
     /kdODo51ov8z7m/z/uvvMfa2SBkzspIn3sxen/fju6ROvDk75yBsMvFBnEolQYUjc5szzaHMfKIaORJm
@@ -102,7 +102,7 @@ def unittest():
     +xSLTTukgmaPw87rkMH+pA4kCxD8WE9lkmFt0aAhrnFobS8V3kpmBhuH03UevzAHcLSjHgvXMtmd1dWk
     i9es9Wmfy8dvwCb0Ug==''' )
 
-  retvals = main( nelems=4, viscosity=1e-3, degree=1, warp=True, tol=1e-15, maxiter=1, withplots=False )
+  retvals = main( nelems=4, viscosity=1e-3, degree=1, warp=True, tol=0, maxiter=1, withplots=False )
   assert debug.checkdata( retvals, '''
     eNrFUllqBDAIvc4MxOIWlwPN/a8wUTOFfhT6VwgY8hafEloPXbSf6/HArzVHGPEFtlhcXrDXN6AxgGzD
     vwG/Wv37ORMDGXGlIkGtCmLZMVk0G7BsAigm1RxgZM0AU22NBUZTGQ9DFxBG7wDceC6S3G5bZwkkLEUl

--- a/examples/elasticity
+++ b/examples/elasticity
@@ -47,16 +47,16 @@ def unittest():
 
   retvals = main( nelems=4, degree=1, withplots=False, solvetol=0 )
   assert debug.checkdata( retvals, '''
-    eNqlkEsKwzAMRK8Tg1z09ec4XXSb+y/r2FZbh0IhBYsZ6Q1YiGBTIAuwbXiDz0ci6REbJNWhoks/OZtw
-    VxXrKpWWfnLJNpXqUMS1H9xwzH/pad1UtI0NOOdyaBtF99FhEaRDldk85D46LCnXHlKur9D00WHJKCMk
-    8g4NHx22q5623O/75bp4mH++/FYBwhP0AIpZ''' )
+    eNqlkEsKwzAMRK8Tg1ysnz/H6aLb3H9Zx7LaOhQKKVjMSG/AQgibAEqAbUs3+HzInB+xQxQxZVn6yUmZ
+    hgrrUG649JNz0anYTFNae+OabP5LT+vmKn2sQKXUQ/souo8OKyc8VIjUQ+6jw5pLGyGh9gpNHx3WkthC
+    zO+Q+eiwX/W05X7fL9fFw/zz5bcKEJ7x0YpY''' )
 
   retvals = main( nelems=4, degree=2, withplots=False, solvetol=0 )
   assert debug.checkdata( retvals, '''
-    eNq1ksEOwyAIhl+nTXQRENDH2aHXvv9xFqRJ1+ywLEtqvr/wi0gLaakJeE3LUh7p7WmgfcucuBQ1UqcL
-    Zzx80LFuedRrx/ugMl8Y8ekjoOIEZxG5MOLTV0lpEp0sV0bcfaO/8g3vE+Be7GaognZThlFZUj5FZHJY
-    tUM7KFSrDUUVzHCKyOSwNgH0LVLsNAI3nCIyOayNxYqJkBGBxLeEiEwOaxPyxmozIvI8JURkcljHb3Gf
-    yf7c/7p+/2r/7vDTWtP6AuDh0ok=''' )
+    eNq1ksEOwyAIhl+nTXQRENDH2aHXvv9xFqRJ1+ywLEtqvr/wi0gLaakJ6pqWpTzS29NA+5Y5cSlqpE4X
+    znj4oGPd8qjXjvdBZb4w4tNHQMUJziJyYcSnr5LSJDpZroy4+0Z/5RveJ8C92M1QBe2mDKOypHyKyOSw
+    aod2UKhWG4oqmOEUkclhbQLoW6TYaQRuOEVkclgbixUTISMCiW8JEZkc1ibkjdVmROR5SojI5LCO3+I+
+    k/25/3X9/tX+3eGntab1Bd2X0og=''' )
 
 
 util.run( main, unittest )

--- a/nutils/matrix.py
+++ b/nutils/matrix.py
@@ -141,7 +141,7 @@ class ScipyMatrix( Matrix ):
     solverfun = getattr( scipy.sparse.linalg, solver )
     if solver == 'spsolve':
       log.info( 'solving system using sparse direct solver' )
-      x = solverfun( A, b, **solverargs )
+      x = solverfun( A, b )
       solverinfo( A, b, x )
     else:
       # keep scipy from making things circular by shielding the nature of A


### PR DESCRIPTION
Fixes failing unit tests on python 3.3 by using a direct solver. It is unclear what exactly causes the issues but differences arise in the solution vector, and disappear when switching to a direct solver or setting a sharper tolerance. The difference may not be due to different python versions but due to difference scipy versions, 0.16.0 vs 0.17.0.