### PR TITLE
Nextfun

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,41 @@ users are advised to keep an eye on this file to stay up to date with
 the most prominent user-facing changes.
 
 
+Changed: function.Inflate, function.DofMap; removed IntVector
+
+  The Inflate class takes a new length argument for the inflated shape.
+  The dofmap argument is now a generic int-array function, which removes
+  the need for a separate IntVector object; DofMap now derives directly
+  from Array.
+
+
+Changed: renamed ElemFunc to LocalCoords
+
+  Besides the name change the new object is derived from
+  DerivativeTargetBase so that it can be used as a derivate target,
+  removing the need for a 'localcoords' special token.
+
+
+Changed: function.asarray
+
+  Formerly asarray returned non-evaluable objects as numpy arrays. The
+  new implementation always returns a nutils Array, wrapping constant
+  objects in function.Constant.
+
+
+New: function.Constant
+
+  Wrapper object that returns a numpy array through evalf, introducing a
+  singleton point axis at location 0.
+
+
+New: function.Array with dtype; deprecates function.ArrayFunc
+
+  ArrayFunc is deprecated and will be removed. The new Array base class
+  is identical to ArrayFunc except for the mandatory argument 'dtype',
+  which takes a value of float, int, or bool.
+
+
 Release history
 ---------------
 

--- a/nutils/cache.py
+++ b/nutils/cache.py
@@ -66,7 +66,7 @@ class HashableArray( HashableBase ):
   # FRAGILE: assumes contents are not going to be changed
   def __init__( self, array ):
     self.array = array
-    self.quickdata = array.shape, tuple( array.flat[::array.size//32+1] ) if array.size else None # required to prevent segfault
+    self.quickdata = array.shape, array.dtype.kind, tuple( array.flat[::array.size//32+1] ) if array.size else None # required to prevent segfault
   def __hash__( self ):
     return hash( self.quickdata )
   def __eq__( self, other ):

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -2532,19 +2532,16 @@ _taketuple = lambda values, index: tuple( values[i] for i in index )
 _issorted = lambda a, b: not isevaluable(b) or isevaluable(a) and id(a) <= id(b)
 _sorted = lambda a, b: (a,b) if _issorted(a,b) else (b,a)
 
-def _jointshape( *shapes ):
+def _jointshape( shape, *shapes ):
   'determine shape after singleton expansion'
 
-  ndim = len(shapes[0])
-  combshape = [1] * ndim
-  for shape in shapes:
-    assert len(shape) == ndim
-    for i, sh in enumerate(shape):
-      if combshape[i] == 1:
-        combshape[i] = sh
-      else:
-        assert sh in ( combshape[i], 1 ), 'incompatible shapes: %s' % ', '.join( str(sh) for sh in shapes )
-  return tuple(combshape)
+  if not shapes:
+    return tuple(shape)
+  other_shape, *remaining_shapes = shapes
+  assert len(shape) == len(other_shape)
+  combined_shape = [ sh1 if sh2 == 1 else sh2 for sh1, sh2 in zip( shape, other_shape ) ]
+  assert all( shc == sh1 for shc, sh1 in zip( combined_shape, shape ) if sh1 != 1 )
+  return _jointshape( combined_shape, *remaining_shapes )
 
 def _matchndim( *arrays ):
   'introduce singleton dimensions to match ndims'

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -364,7 +364,7 @@ class Array( Evaluable ):
 
   @property
   def blocks( self ):
-    return [( Tuple([ numpy.arange(n) if numeric.isint(n) else None for n in self.shape ]), self )]
+    return [( Tuple([ asarray(numpy.arange(n)) if numeric.isint(n) else None for n in self.shape ]), self )]
 
   def vector( self, ndims ):
     'vectorize'
@@ -676,7 +676,7 @@ class DofMap( Array ):
   def evalf( self, trans ):
     'evaluate'
 
-    return self.dofmap[ trans.lookup(self.dofmap) ] + self.offset
+    return ( self.dofmap[ trans.lookup(self.dofmap) ] + self.offset )[_]
 
   def _opposite( self ):
     return DofMap( self.dofmap, self.shape[0], 1-self.side )
@@ -1703,8 +1703,6 @@ class Take( Array ):
     Array.__init__( self, args=[func,indices], shape=shape, dtype=func.dtype )
 
   def evalf( self, arr, indices ):
-    if indices.ndim == 1:
-      indices = indices[_] # temporary hack to work with non-compliant DofMap
     if indices.shape[0] != 1:
       raise NotImplementedError( 'non element-constant indexing not supported yet' )
     return numpy.take( arr, indices[0], self.axis+1 )
@@ -2060,6 +2058,9 @@ class Inflate( Array ):
   def evalf( self, array, indices ):
     'inflate'
 
+    if indices.shape[0] != 1:
+      raise NotImplementedError
+    indices, = indices
     assert array.ndim == self.ndim+1
     warnings.warn( 'using explicit inflation; this is usually a bug.' )
     shape = list( array.shape )

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -1413,9 +1413,9 @@ class Multiply( Array ):
 
   def _add( self, other ):
     func1, func2 = self.funcs
-    if _equal( other, func1 ):
+    if other == func1:
       return func1 * (func2+1)
-    if _equal( other, func2 ):
+    if other == func2:
       return func2 * (func1+1)
     if isinstance( other, Multiply ):
       common = _findcommon( self.funcs, other.funcs )
@@ -2594,13 +2594,13 @@ def _findcommon( a, b ):
 
   a1, a2 = a
   b1, b2 = b
-  if _equal( a1, b1 ):
+  if a1 == b1:
     return a1, (a2,b2)
-  if _equal( a1, b2 ):
+  if a1 == b2:
     return a1, (a2,b1)
-  if _equal( a2, b1 ):
+  if a2 == b1:
     return a2, (a1,b2)
-  if _equal( a2, b2 ):
+  if a2 == b2:
     return a2, (a1,b1)
 
 _max = max
@@ -2651,24 +2651,6 @@ def _dtypestr( arg ):
   if arg.dtype == float:
     return 'double'
   raise Exception( 'unknown dtype %s' % arg.dtype )
-
-def _equal( arg1, arg2 ):
-  'compare two objects'
-
-  if arg1 is arg2:
-    return True
-  if isinstance( arg1, dict ) or isinstance( arg2, dict ):
-    return False
-  if isinstance( arg1, (list,tuple) ):
-    if not isinstance( arg2, (list,tuple) ) or len(arg1) != len(arg2):
-      return False
-    return all( _equal(v1,v2) for v1, v2 in zip( arg1, arg2 ) )
-  if not isinstance( arg1, numpy.ndarray ) and not isinstance( arg2, numpy.ndarray ):
-    return arg1 == arg2
-  elif isinstance( arg1, numpy.ndarray ) and isinstance( arg2, numpy.ndarray ):
-    return arg1.shape == arg2.shape and numpy.all( arg1 == arg2 )
-  else:
-    return False
 
 
 # FUNCTIONS
@@ -3250,7 +3232,7 @@ def multiply( arg1, arg2 ):
   arg1, arg2 = _matchndim( arg1, arg2 )
   shape = _jointshape( arg1.shape, arg2.shape )
 
-  if _equal( arg1, arg2 ):
+  if arg1 == arg2:
     return power( arg1, 2 )
 
   for idim, sh in enumerate( shape ):
@@ -3281,7 +3263,7 @@ def add( arg1, arg2 ):
   if iszero( arg2 ):
     return expand( arg1, shape )
 
-  if _equal( arg1, arg2 ):
+  if arg1 == arg2:
     return arg1 * 2
 
   for idim, sh in enumerate( shape ):

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -812,7 +812,9 @@ class Get( Array ):
     self.axis = axis
     self.item = item
     assert 0 <= axis < func.ndim, 'axis is out of bounds'
-    assert 0 <= item < func.shape[axis], 'item is out of bounds'
+    assert 0 <= item
+    if numeric.isint( func.shape[axis] ):
+      assert item < func.shape[axis], 'item is out of bounds'
     self.item_shiftright = (Ellipsis,item) + (slice(None),)*(func.ndim-axis-1)
     shape = func.shape[:axis] + func.shape[axis+1:]
     Array.__init__( self, args=[func], shape=shape, dtype=func.dtype )
@@ -2269,7 +2271,9 @@ class Repeat( Array ):
 
   def _get( self, axis, item ):
     if axis == self.axis:
-      assert 0 <= item < self.length
+      assert 0 <= item
+      if numeric.isint(self.length):
+        assert item < self.length
       return get( self.func, axis, 0 )
     return repeat( get( self.func, axis, item ), self.length, self.axis-(axis<self.axis) )
 
@@ -3451,7 +3455,13 @@ def take( arg, index, axis ):
   axis = numeric.normdim( arg.ndim, axis )
 
   if isinstance( index, slice ):
-    index = numpy.arange(arg.shape[axis])[index]
+    if numeric.isint( arg.shape[axis] ):
+      index = numpy.arange(arg.shape[axis])[index]
+    else:
+      assert index.start == None or index.start >= 0
+      assert index.step == None or index.step == 1
+      assert index.stop != None and index.stop >= 0
+      index = numpy.arange( index.start or 0, index.stop )
 
   index = asarray( index )
   assert index.ndim == 1

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -556,6 +556,13 @@ class Array( Evaluable ):
 
   __repr__ = __str__
 
+class ArrayFunc( Array ):
+  'deprecated ArrayFunc alias'
+
+  def __init__( self, args, shape ):
+    warnings.warn( 'function.ArrayFunc is deprecated; use function.Array instead', DeprecationWarning )
+    Array.__init__( self, args=args, shape=shape, dtype=float )
+
 class Constant( Array ):
   'constant'
 

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -610,7 +610,7 @@ class Constant( Array ):
     return self.value[_]
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( self.shape + _taketuple(var.shape,axes) )
+    return zeros( self.shape + _taketuple(var.shape,axes) )
 
   def _align( self, axes, ndim ):
     return asarray( numeric.align( self.value, axes, ndim ) )
@@ -716,7 +716,7 @@ class Orientation( Array ):
     return Orientation( self.ndims, 1-self.side )
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( _taketuple(var.shape,axes) )
+    return zeros( _taketuple(var.shape,axes) )
 
 class Align( Array ):
   'align axes'
@@ -901,7 +901,7 @@ class Transform( Array ):
     return matrix.astype( float )[_]
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( self.shape+_taketuple(var.shape,axes) )
+    return zeros( self.shape+_taketuple(var.shape,axes) )
 
   def _opposite( self ):
     return Transform( self.todims, self.fromdims, 1-self.side )
@@ -1008,7 +1008,7 @@ class Choose( Array ):
   def _derivative( self, var, axes, seen ):
     grads = [ derivative( choice, var, axes, seen ) for choice in self.choices ]
     if not any( grads ): # all-zero special case; better would be allow merging of intervals
-      return _zeros( self.shape + _taketuple(var.shape,axes) )
+      return zeros( self.shape + _taketuple(var.shape,axes) )
     return choose( self.level[(...,)+(_,)*len(axes)], grads )
 
   def _edit( self, op ):
@@ -1368,7 +1368,7 @@ class DofIndex( Array ):
       return take( self.array + other.array, self.index, self.iax )
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( self.shape + _taketuple(var.shape,axes) )
+    return zeros( self.shape + _taketuple(var.shape,axes) )
 
   def _concatenate( self, other, axis ):
     if isinstance( other, DofIndex ) and self.iax == other.iax and self.index == other.index:
@@ -1798,7 +1798,7 @@ class Power( Array ):
   def _power( self, n ):
     func = self.func
     newpower = n * self.power
-    if _iszero( self.power % 2 ) and not _iszero( newpower % 2 ):
+    if iszero( self.power % 2 ) and not iszero( newpower % 2 ):
       func = abs( func )
     return power( func, newpower )
 
@@ -1822,7 +1822,7 @@ class Power( Array ):
       return power( self.func, self.power + 1 )
 
   def _sign( self ):
-    if _iszero( self.power % 2 ):
+    if iszero( self.power % 2 ):
       return expand( 1., self.shape )
 
   def _edit( self, op ):
@@ -1877,7 +1877,7 @@ class Sign( Array ):
     return numpy.sign( arr )
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( self.shape + _taketuple(var.shape,axes) )
+    return zeros( self.shape + _taketuple(var.shape,axes) )
 
   def _takediag( self ):
     return sign( takediag(self.func) )
@@ -1892,7 +1892,7 @@ class Sign( Array ):
     return self
 
   def _power( self, n ):
-    if _iszero( n % 2 ):
+    if iszero( n % 2 ):
       return expand( 1., self.shape )
 
   def _edit( self, op ):
@@ -1967,7 +1967,7 @@ class Elemwise( Array ):
     return value[_]
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( self.shape+_taketuple(var.shape,axes) )
+    return zeros( self.shape+_taketuple(var.shape,axes) )
 
   def _opposite( self ):
     return Elemwise( self.fmap, self.shape, self.default, 1-self.side )
@@ -2026,10 +2026,10 @@ class Zeros( Array ):
 
   def _repeat( self, length, axis ):
     assert self.shape[axis] == 1
-    return _zeros( self.shape[:axis] + (length,) + self.shape[axis+1:] )
+    return zeros( self.shape[:axis] + (length,) + self.shape[axis+1:] )
 
   def _derivative( self, var, axes, seen ):
-    return _zeros( self.shape+_taketuple(var.shape,axes) )
+    return zeros( self.shape+_taketuple(var.shape,axes) )
 
   def _add( self, other ):
     shape = _jointshape( self.shape, other.shape )
@@ -2037,41 +2037,41 @@ class Zeros( Array ):
 
   def _multiply( self, other ):
     shape = _jointshape( self.shape, other.shape )
-    return _zeros( shape )
+    return zeros( shape )
 
   def _dot( self, other, naxes ):
     shape = _jointshape( self.shape, other.shape )
-    return _zeros( shape[:-naxes] )
+    return zeros( shape[:-naxes] )
 
   def _cross( self, other, axis ):
     shape = _jointshape( self.shape, other.shape )
-    return _zeros( shape )
+    return zeros( shape )
 
   def _diagonalize( self ):
-    return _zeros( self.shape + (self.shape[-1],) )
+    return zeros( self.shape + (self.shape[-1],) )
 
   def _sum( self, axis ):
-    return _zeros( self.shape[:axis] + self.shape[axis+1:] )
+    return zeros( self.shape[:axis] + self.shape[axis+1:] )
 
   def _align( self, axes, ndim ):
     shape = [1] * ndim
     for ax, sh in zip( axes, self.shape ):
       shape[ax] = sh
-    return _zeros( shape )
+    return zeros( shape )
 
   def _get( self, i, item ):
-    return _zeros( self.shape[:i] + self.shape[i+1:] )
+    return zeros( self.shape[:i] + self.shape[i+1:] )
 
   def _takediag( self ):
     sh = _max( self.shape[-2], self.shape[-1] )
-    return _zeros( self.shape[:-2] + (sh,) )
+    return zeros( self.shape[:-2] + (sh,) )
 
   def _take( self, index, axis ):
-    return _zeros( self.shape[:axis] + index.shape + self.shape[axis+1:] )
+    return zeros( self.shape[:axis] + index.shape + self.shape[axis+1:] )
 
   def _inflate( self, dofmap, axis ):
     assert not isinstance( self.shape[axis], int )
-    return _zeros( self.shape[:axis] + (dofmap.target,) + self.shape[axis+1:] )
+    return zeros( self.shape[:axis] + (dofmap.target,) + self.shape[axis+1:] )
 
   def _power( self, n ):
     return self
@@ -2079,7 +2079,7 @@ class Zeros( Array ):
   def _pointwise( self, evalf, deriv ):
     value = evalf( *numpy.zeros(self.shape[0]) )
     if value == 0:
-      return _zeros( self.shape[1:] )
+      return zeros( self.shape[1:] )
     return expand( numpy.array(value)[(_,)*(self.ndim-1)], self.shape[1:] )
 
   def _revolved( self ):
@@ -2447,7 +2447,7 @@ class DerivativeTarget( DerivativeTargetBase ):
         result = result * align( eye( self.shape[axis] ), ( axis, self.ndim+i ), self.ndim+len(axes) )
       return result
     else:
-      return _zeros( self.shape+_taketuple(var.shape,axes) )
+      return zeros( self.shape+_taketuple(var.shape,axes) )
 
 class LocalCoords( DerivativeTargetBase ):
   'trivial func'
@@ -2470,7 +2470,7 @@ class LocalCoords( DerivativeTargetBase ):
       return eye( ndims ) if self.shape[0] == ndims \
         else Transform( self.shape[0], ndims, self.side )
     else:
-      return _zeros( self.shape+_taketuple(var.shape,axes) )
+      return zeros( self.shape+_taketuple(var.shape,axes) )
 
   def _opposite( self ):
     ndims, = self.shape
@@ -2495,7 +2495,7 @@ class RevolutionAngle( Array ):
       lgrad[-1] = 2*numpy.pi
       return lgrad
     else:
-      return _zeros( _taketuple(var.shape,axes) )
+      return zeros( _taketuple(var.shape,axes) )
 
 class Revolved( Array ):
   'implement an extra local dimension with zero gradient'
@@ -2515,10 +2515,10 @@ class Revolved( Array ):
   def _derivative( self, var, axes, seen ):
     if isinstance( var, LocalCoords ):
       newvar = LocalCoords( var.shape[0]-1 )
-      return revolved( concatenate( [ derivative(self.func,newvar,axes,seen), _zeros(self.func.shape+(1,)) ], axis=-1 ) )
+      return revolved( concatenate( [ derivative(self.func,newvar,axes,seen), zeros(self.func.shape+(1,)) ], axis=-1 ) )
     else:
       result = derivative( self.func, var, axes, seen )
-      assert _iszero( result )
+      assert iszero( result )
       return result
 
   def _edit( self, op ):
@@ -2600,12 +2600,9 @@ _abs = abs
 _isevaluable = lambda arg: isinstance( arg, Evaluable )
 _isscalar = lambda arg: asarray(arg).ndim == 0
 _ascending = lambda arg: ( numpy.diff(arg) > 0 ).all()
-_iszero = lambda arg: isinstance( arg, Zeros )
 _isunit = lambda arg: not isarray(arg) and ( numpy.asarray(arg) == 1 ).all()
 _subsnonesh = lambda shape: tuple( 1 if sh is None else sh for sh in shape )
 _normdims = lambda ndim, shapes: tuple( numeric.normdim(ndim,sh) for sh in shapes )
-_zeros = lambda shape: Zeros( shape )
-_zeros_like = lambda arr: _zeros( arr.shape )
 _taketuple = lambda values, index: tuple( values[i] for i in index )
 
 # for consistency in Add and Multiply arguments: the smallest Evaluable first
@@ -2677,7 +2674,7 @@ def asarray( arg ):
     array = numpy.asarray( arg )
     assert array.dtype != object
     if numpy.all( array == 0 ):
-      return _zeros( array.shape )
+      return zeros( array.shape )
     return Constant( array )
 
   return stack( arg, axis=0 )
@@ -2703,7 +2700,7 @@ def chain( funcs ):
 
   funcs = [ asarray(func) for func in funcs ]
   shapes = [ func.shape[0] for func in funcs ]
-  return [ concatenate( [ func if i==j else _zeros( (sh,) + func.shape[1:] )
+  return [ concatenate( [ func if i==j else zeros( (sh,) + func.shape[1:] )
              for j, sh in enumerate(shapes) ], axis=0 )
                for i, func in enumerate(funcs) ]
 
@@ -2887,8 +2884,8 @@ def dot( arg1, arg2, axes ):
   axes = _norm_and_sort( len(shape), axes )
   assert numpy.all( numpy.diff(axes) > 0 ), 'duplicate axes in sum'
 
-  if _iszero( arg1 ) or _iszero( arg2 ):
-    return _zeros([ s for i, s in enumerate(shape) if i not in axes ])
+  if iszero( arg1 ) or iszero( arg2 ):
+    return zeros([ s for i, s in enumerate(shape) if i not in axes ])
 
   if _isunit( arg1 ):
     return sum( expand( arg2, shape ), axes )
@@ -3093,7 +3090,7 @@ def kronecker( arg, axis, length, pos ):
 
   axis = numeric.normdim( arg.ndim+1, axis )
   arg = insert( arg, axis )
-  args = [ _zeros_like(arg) ] * length
+  args = [ zeros_like(arg) ] * length
   args[pos] = arg
   return concatenate( args, axis=axis )
 
@@ -3120,7 +3117,7 @@ def concatenate( args, axis=0 ):
   axis = numeric.normdim( args[0].ndim, axis )
   i = 0
 
-  if all( _iszero(arg) for arg in args ):
+  if all( iszero(arg) for arg in args ):
     shape = list( args[0].shape )
     axis = numeric.normdim( len(shape), axis )
     for arg in args[1:]:
@@ -3131,7 +3128,7 @@ def concatenate( args, axis=0 ):
           shape[i] = arg.shape[i]
         else:
           assert arg.shape[i] in (shape[i],1)
-    return _zeros( shape )
+    return zeros( shape )
 
   while i+1 < len(args):
     arg1, arg2 = args[i:i+2]
@@ -3182,8 +3179,8 @@ def choose( level, choices ):
 
   level, *choices = _matchndim( level, *choices )
   shape = _jointshape( level.shape, *( choice.shape for choice in choices ) )
-  if all( map( _iszero, choices ) ):
-    return _zeros( shape )
+  if all( map( iszero, choices ) ):
+    return zeros( shape )
   retval = _call( level, '_choose', choices )
   if retval is not None:
     assert retval.shape == shape, 'bug in %s._choose' % level
@@ -3281,10 +3278,10 @@ def add( arg1, arg2 ):
   arg1, arg2 = _matchndim( arg1, arg2 )
   shape = _jointshape( arg1.shape, arg2.shape )
 
-  if _iszero( arg1 ):
+  if iszero( arg1 ):
     return expand( arg2, shape )
 
-  if _iszero( arg2 ):
+  if iszero( arg2 ):
     return expand( arg1, shape )
 
   if _equal( arg1, arg2 ):
@@ -3337,7 +3334,7 @@ def power( arg, n ):
   arg, n = _matchndim( arg, n )
   shape = _jointshape( arg.shape, n.shape )
 
-  if _iszero( n ):
+  if iszero( n ):
     return numpy.ones( shape )
 
   retval = _call( arg, '_power', n )
@@ -3415,6 +3412,9 @@ def revolved( arg ):
   return Revolved( arg )
 
 isarray = lambda arg: isinstance( arg, Array )
+iszero = lambda arg: isinstance( arg, Zeros )
+zeros = lambda shape: Zeros( shape )
+zeros_like = lambda arr: zeros( arr.shape )
 grad = lambda arg, coords, ndims=0: asarray( arg ).grad( coords, ndims )
 symgrad = lambda arg, coords, ndims=0: asarray( arg ).symgrad( coords, ndims )
 div = lambda arg, coords, ndims=0: asarray( arg ).div( coords, ndims )
@@ -3436,12 +3436,12 @@ log2 = lambda arg: ln(arg) / ln(2)
 log10 = lambda arg: ln(arg) / ln(10)
 sqrt = lambda arg: power( arg, .5 )
 reciprocal = lambda arg: power( arg, -1 )
-argmin = lambda arg, axis: pointwise( bringforward(arg,axis), lambda *x: numpy.argmin(numeric.stack(x),axis=0), _zeros_like )
-argmax = lambda arg, axis: pointwise( bringforward(arg,axis), lambda *x: numpy.argmax(numeric.stack(x),axis=0), _zeros_like )
+argmin = lambda arg, axis: pointwise( bringforward(arg,axis), lambda *x: numpy.argmin(numeric.stack(x),axis=0), zeros_like )
+argmax = lambda arg, axis: pointwise( bringforward(arg,axis), lambda *x: numpy.argmax(numeric.stack(x),axis=0), zeros_like )
 arctan2 = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.arctan2, lambda x: stack([x[1],-x[0]]) / sum(power(x,2),0) )
-greater = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.greater, _zeros_like )
-equal = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.equal, _zeros_like )
-less = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.less, _zeros_like )
+greater = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.greater, zeros_like )
+equal = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.equal, zeros_like )
+less = lambda arg1, arg2=None: pointwise( arg1 if arg2 is None else [arg1,arg2], numpy.less, zeros_like )
 min = lambda arg1, *args: choose( argmin( arg1 if not args else (arg1,)+args, axis=0 ), arg1 if not args else (arg1,)+args )
 max = lambda arg1, *args: choose( argmax( arg1 if not args else (arg1,)+args, axis=0 ), arg1 if not args else (arg1,)+args )
 abs = lambda arg: arg * sign(arg)

--- a/nutils/index.py
+++ b/nutils/index.py
@@ -10,14 +10,14 @@ import sys, collections, operator, numbers
 
 
 class IndexedArray:
-  '''wrapper of `ArrayFunc` with index notation and Einstein summation convention
+  '''wrapper of `Array` with index notation and Einstein summation convention
 
-  This wrapper adds indices to the axes of the wrapped `ArrayFunc` which is used
-  to align the `ArrayFunc` with other wrapped `ArrayFunc`s when doing simple
+  This wrapper adds indices to the axes of the wrapped `Array` which is used
+  to align the `Array` with other wrapped `Array`s when doing simple
   arithmetic operations.  In addition, repeated indices are summed (Einstein
   summation convention).
 
-  Passing an index string to `a[...]`, with `a` an `ArrayFunc`, wraps the array
+  Passing an index string to `a[...]`, with `a` an `Array`, wraps the array
   func.  The number of indices must match the number of axes of `a`.  The index
   string may contain only lower case latin characters.  A wrapped array can be
   unwrapped via the `unwrap` method.
@@ -27,7 +27,7 @@ class IndexedArray:
   respectively a gradient or surface gradient is computed with respect to the
   geometry specified in the `unwrap` method.
 
-  Examples.  Let `a` and `b` be `ArrayFunc`s with shape `(n,n)` and `(n,)`.  The
+  Examples.  Let `a` and `b` be `Array`s with shape `(n,n)` and `(n,)`.  The
   following pairs are equivalent when unwrapped with geometry `geom`:
 
       a['ij']*b['j']
@@ -71,23 +71,23 @@ class IndexedArray:
     return len( self.indices )
 
   def unwrap( self, geometry=None, indices=None ):
-    '''unwrap the `ArrayFunc` aligned according to `indices`
+    '''unwrap the `Array` aligned according to `indices`
 
     Parameters
     ----------
-    geometry : ArrayFunc, optional
+    geometry : Array, optional
         The geometry used when computing gradients.  This argument is mandatory
         when this `IndexedArray` contains gradients, otherwise this argument is
         ignored.
     indices : str, optional
-        This indicates the order of the axes of the unwrapped `ArrayFunc`.
+        This indicates the order of the axes of the unwrapped `Array`.
         `indices` must contain all indices of this `IndexedArray`, may not have
         repeated indices and may not have indices other than those of this
         `IndexedArray`.
 
     Returns
     -------
-    ArrayFunc
+    Array
     '''
 
     if indices is None:
@@ -240,7 +240,7 @@ def asindexedarray( arg ):
 
   if isinstance( arg, IndexedArray ):
     return arg
-  elif isinstance( arg, (function.ArrayFunc, numpy.ndarray) ) and len( arg.shape ) == 0:
+  elif isinstance( arg, (function.Array, numpy.ndarray) ) and len( arg.shape ) == 0:
     return IndexedArray( '', lambda geom: arg, () )
   elif isinstance( arg, (numbers.Number, numpy.generic) ):
     return IndexedArray( '', lambda geom: numpy.array( arg ), () )
@@ -248,11 +248,11 @@ def asindexedarray( arg ):
     raise ValueError( 'cannot convert {!r} to a `IndexedArray`'.format( arg ) )
 
 def wrap( array, indices ):
-  '''wrap a scalar, numpy array or `ArrayFunc` in an `IndexedArray`
+  '''wrap a scalar, numpy array or `Array` in an `IndexedArray`
 
   Parameters
   ----------
-  array : scalar, numpy.ndarray or function.ArrayFunc
+  array : scalar, numpy.ndarray or function.Array
   indices : str
 
   Returns

--- a/nutils/mesh.py
+++ b/nutils/mesh.py
@@ -90,7 +90,7 @@ def gmesh( fname, tags={}, name=None, use_elementary=False ):
 
   Returns:
       topo (:class:`nutils.topology.Topology`): Topology of parsed Gmesh file
-      geom (:class:`nutils.function.ArrayFunc`): Isoparametric map
+      geom (:class:`nutils.function.Array`): Isoparametric map
 
   """
 

--- a/nutils/parallel.py
+++ b/nutils/parallel.py
@@ -160,6 +160,9 @@ def shzeros( shape, dtype=float ):
   elif dtype == int:
     typecode = 'i'
     dtype = numpy.int32
+  elif dtype == bool:
+    typecode = 'b'
+    dtype = numpy.int8
   else:
     raise Exception( 'invalid dtype: %r' % dtype )
   buf = multiprocessing.RawArray( typecode, int(size) )

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -249,7 +249,7 @@ class Topology( object ):
     for ifunc, func in enumerate( funcs ):
       func = function.asarray( edit( func * iwscale ) )
       retval = parallel.shzeros( (npoints,)+func.shape, dtype=func.dtype )
-      if function._isfunc( func ):
+      if function.isarray( func ):
         for ind, f in function.blocks( func ):
           idata.append( function.Tuple([ ifunc, ind, f ]) )
       else:

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -262,7 +262,7 @@ class Topology( object ):
       ipoints, iweights = fcache[elem.reference.getischeme]( ischeme )
       s = slices[ielem],
       for ifunc, index, data in idata.eval( elem, ipoints, fcache ):
-        retvals[ifunc][s+numpy.ix_(*index)] += numeric.dot(iweights,data) if geometry else data
+        retvals[ifunc][s+numpy.ix_(*[ ind for (ind,) in index ])] += numeric.dot(iweights,data) if geometry else data
 
     log.debug( 'cache', fcache.stats )
     log.info( 'created', ', '.join( '%s(%s)' % ( retval.__class__.__name__, ','.join( str(n) for n in retval.shape ) ) for retval in retvals ) )
@@ -317,9 +317,9 @@ class Topology( object ):
 
     for ielem, elem in enumerate( self ):
       for iblock, index in enumerate( indexfunc.eval( elem, None, fcache ) ):
-        n = util.product( len(ind) for ind in index ) if index else 1
+        n = util.product( len(ind) for (ind,) in index ) if index else 1
         offsets[iblock,ielem+1] = offsets[iblock,ielem] + n
-        indices[iblock].append( index )
+        indices[iblock].append([ ind for (ind,) in index ])
 
     # Since several blocks may belong to the same function, we post process the
     # offsets to form consecutive intervals in longer arrays. The length of

--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -621,7 +621,8 @@ class Topology( object ):
     for axes, func in function.blocks( basis ):
       dofmap = axes[0]
       for elem in self:
-        used[ dofmap.dofmap[elem.transform] + dofmap.offset ] = True
+        dofs = dofmap.eval( elem )
+        used[dofs] = True
     return basis[used]
 
   def locate( self, geom, points, ischeme='vertex', scale=1, tol=1e-12, eps=0, maxiter=100 ):
@@ -1725,11 +1726,11 @@ class HierarchicalTopology( Topology ):
       myelems = [] # all top-level or parent elements in current level
 
       (axes,func), = function.blocks( funcsp )
-      dofmap = axes[0].dofmap
+      dofmap, = axes
       stdmap = func.stdmap
       for elem in topo:
         trans = elem.transform
-        idofs = dofmap[trans]
+        idofs, = dofmap.eval( elem )
         stds = stdmap[trans]
         mytrans = trans.lookup( self.edict )
         if mytrans == trans: # trans is in domain

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -4,12 +4,12 @@ from . import \
   normals,    \
   mesh,       \
   ischeme,    \
-  finitecell, \
   pointdata,  \
   topology,   \
   doubleint,  \
   quadrature, \
   element,    \
+  finitecell, \
   runtests
 
 runtests()

--- a/tests/finitecell.py
+++ b/tests/finitecell.py
@@ -9,7 +9,7 @@ def cutdomain( ndims, nelems, maxrefine, errtol ):
 
   domain, geom = mesh.rectilinear( (numpy.linspace(0,1,nelems+1),)*ndims )
   radius = numpy.sqrt( .5 )
-  levelset = radius**2 - ( geom**2 ).sum()
+  levelset = radius**2 - ( geom**2 ).sum(-1)
   pos = domain.trim( levelset=levelset, maxrefine=maxrefine )
   neg = domain - pos
   V = 1.

--- a/tests/function.py
+++ b/tests/function.py
@@ -37,11 +37,11 @@ from . import register, unittest
 @register( 'inverse323', lambda a: function.inverse(a,(0,2)), lambda a: numpy.linalg.inv(a.swapaxes(-3,-2)).swapaxes(-3,-2), [(3,2,3)] )
 @register( 'repeat', lambda a: function.repeat(a,3,1), lambda a: numpy.repeat(a,3,-2), [(2,1,2)] )
 @register( 'diagonalize', function.diagonalize, numeric.diagonalize, [(2,1,2)] )
-@register( 'multiply', lambda a,b: a * b, numpy.multiply, [(3,1),(1,3)] )
-@register( 'divide', lambda a,b: a / b, numpy.divide, [(3,1),(1,3)] )
-@register( 'add', lambda a,b: a + b, numpy.add, [(3,1),(1,3)] )
-@register( 'subtract', lambda a,b: a - b, numpy.subtract, [(3,1),(1,3)] )
-@register( 'product2', lambda a,b: (a*b).sum(-2), lambda a,b: (a*b).sum(-2), [(2,3,1),(1,3,2)] )
+@register( 'multiply', function.multiply, numpy.multiply, [(3,1),(1,3)] )
+@register( 'divide', function.divide, numpy.divide, [(3,1),(1,3)] )
+@register( 'add', function.add, numpy.add, [(3,1),(1,3)] )
+@register( 'subtract', function.subtract, numpy.subtract, [(3,1),(1,3)] )
+@register( 'product2', lambda a,b: function.multiply(a,b).sum(-2), lambda a,b: (a*b).sum(-2), [(2,3,1),(1,3,2)] )
 @register( 'cross', lambda a,b: function.cross(a,b,-2), lambda a,b: numpy.cross(a,b,axis=-2), [(2,3,1),(1,3,2)] )
 @register( 'min', lambda a,b: function.min(a,b), numpy.minimum, [(3,1),(1,3)] )
 @register( 'max', lambda a,b: function.max(a,b), numpy.maximum, [(3,1),(1,3)] )
@@ -49,9 +49,10 @@ from . import register, unittest
 @register( 'less', lambda a,b: function.less(a,b), numpy.less, [(3,1),(1,3)] )
 @register( 'arctan2', function.arctan2, numpy.arctan2, [(3,1),(1,3)] )
 @register( 'stack', lambda a,b: function.stack([a,b]), lambda a,b: numpy.concatenate( [a[...,_,:],b[...,_,:]], axis=-2), [(3,),(3,)] )
-@register( 'eig', lambda a: function.eig(a,symmetric=False)[1], lambda a: numpy.array([ numpy.linalg.eig(ai)[1] for ai in a ]), [(3,3)], hasgrad=False )
+@register( 'eig', lambda a: function.eig(a,symmetric=False)[1], lambda a: numpy.linalg.eig(a)[1], [(3,3)], hasgrad=False )
 @register( 'trignormal', lambda a: function.trignormal(a), lambda a: numpy.array([ numpy.cos(a), numpy.sin(a) ]).T, [()] )
 @register( 'trigtangent', lambda a: function.trigtangent(a), lambda a: numpy.array([ -numpy.sin(a), numpy.cos(a) ]).T, [()] )
+@register( 'mod', lambda a,b: function.mod(a,b), lambda a,b: numpy.mod(a,b), [(3,),(3,)], hasgrad=False )
 def check( op, n_op, shapes, hasgrad=True ):
 
   anchor = transform.roottrans( 'test', (0,0) )
@@ -73,6 +74,11 @@ def check( op, n_op, shapes, hasgrad=True ):
 
   argsfun = function.Tuple( args )
   invroottransmatrix = roottrans.invlinear.astype( float )
+
+  @unittest
+  def evalconst():
+    constargs = [ numpy.random.uniform( size=shape ) for shape in shapes ]
+    numpy.all( n_op( *constargs ) == op( *constargs ).eval(elem,points) )
 
   @unittest
   def eval():

--- a/tests/function.py
+++ b/tests/function.py
@@ -45,6 +45,7 @@ from . import register, unittest
 @register( 'cross', lambda a,b: function.cross(a,b,-2), lambda a,b: numpy.cross(a,b,axis=-2), [(2,3,1),(1,3,2)] )
 @register( 'min', lambda a,b: function.min(a,b), numpy.minimum, [(3,1),(1,3)] )
 @register( 'max', lambda a,b: function.max(a,b), numpy.maximum, [(3,1),(1,3)] )
+@register( 'equal', lambda a,b: function.equal(a,b), numpy.equal, [(3,1),(1,3)] )
 @register( 'greater', lambda a,b: function.greater(a,b), numpy.greater, [(3,1),(1,3)] )
 @register( 'less', lambda a,b: function.less(a,b), numpy.less, [(3,1),(1,3)] )
 @register( 'arctan2', function.arctan2, numpy.arctan2, [(3,1),(1,3)] )

--- a/tests/normals.py
+++ b/tests/normals.py
@@ -28,7 +28,7 @@ def check( ndims, curved ):
     f = ( funcsp[:,_] * numpy.arange(funcsp.shape[0]*ndims).reshape(-1,ndims) ).sum(0)
     g = funcsp.dot( numpy.arange(funcsp.shape[0]) )
 
-    fg1 = domain.integrate( ( f * g.grad(geom) ).sum(), geometry=geom, ischeme='gauss2' )
+    fg1 = domain.integrate( ( f * g.grad(geom) ).sum(-1), geometry=geom, ischeme='gauss2' )
     fg2 = domain.boundary.integrate( (f*g).dotnorm(geom), geometry=geom, ischeme='gauss2' ) \
         - domain.interfaces.integrate( function.jump(f*g).dotnorm(geom), geometry=geom, ischeme='gauss2' ) \
         - domain.integrate( f.div(geom) * g, geometry=geom, ischeme='gauss2' )


### PR DESCRIPTION
Some cleanups in the function module in preparation for a larger overhaul. Notable differences:
- rename ArrayFunc to Array
- introduce Constant for arrays
- remove Indexvector and DofIndex, make DofMap a proper Array
- add mandatory Array dtype (supporting only float, int, bool)
- fix singleton expansion in take of Multiply, Dot, Add, Cross, Concatenate
- make Array._dot equal to function.dot (naxes->axes)
- add Diagonalize._dot, _take, to maintain sparsity of partial derivatives

TODO (possibly in subsequent pull):
- replace Concatenate with summation; proposing to introduce a new ZeroPad operand (name up for debate) and rename Inflate to Scatter, with counterparts TakeSlice and Take.
- postpone all tree manipulations until serialization, maybe by merging with 'blocks'