### PR TITLE
Fixpower

### DIFF
--- a/examples/finitestrain
+++ b/examples/finitestrain
@@ -23,7 +23,7 @@ def main( nelems=12, stress=library.Hooke(lmbda=1,mu=1), degree=2, angle=15, res
 
   if trim:
     levelset = function.norm2( geom0 - (.5,.5) ) - .2
-    domain, complement = domain.trim( levelset, maxrefine=2 )
+    domain = domain.trim( levelset, maxrefine=2 )
 
   dbasis = domain.basis( 'spline', degree=degree ).vector( 2 )
 

--- a/nutils/function.py
+++ b/nutils/function.py
@@ -616,7 +616,7 @@ class Constant( Array ):
 
   def _power( self, n ):
     if isinstance( n, Constant ):
-      return asarray( numpy.power( self.value, n.value ) )
+      return asarray( numeric.power( self.value, n.value ) )
 
   def _edit( self, op ):
     return asarray( op(self.value) )
@@ -694,7 +694,7 @@ class ElementSize( Array):
 
   def evalf( self, iwscale ):
     volume = iwscale.sum()
-    return numpy.power( volume, 1/self.ndims )[_]
+    return numeric.power( volume, 1/self.ndims )[_]
 
 class Orientation( Array ):
   'sign'
@@ -1748,10 +1748,10 @@ class Power( Array ):
     self.func = func
     self.power = power
     shape = _jointshape( func.shape, power.shape )
-    Array.__init__( self, args=[func,power], shape=shape, dtype=_jointdtype(func.dtype,power.dtype) )
+    Array.__init__( self, args=[func,power], shape=shape, dtype=float )
 
   def evalf( self, base, exp ):
-    return numpy.power( base, exp )
+    return numeric.power( base, exp )
 
   def _derivative( self, var, axes, seen ):
     # self = func**power

--- a/nutils/numeric.py
+++ b/nutils/numeric.py
@@ -551,5 +551,11 @@ def fhex( A ):
   h = '{:+x}'.format( mantissa << mod )[1:]
   return ( '-' if mantissa < 0 else '' ) + '0x' + ( h.ljust( len(h)+div, '0' ) if div >= 0 else ( h[:div] or '0' ) + '.' + h[div:].rjust( -div, '0' ) )
 
+def power( a, b ):
+  a = numpy.asarray( a )
+  b = numpy.asarray( b )
+  if a.dtype == int and b.dtype == int:
+    b = b.astype( float )
+  return numpy.power( a, b )
 
 # vim:shiftwidth=2:softtabstop=2:expandtab:foldmethod=indent:foldnestmax=2

--- a/tests/function.py
+++ b/tests/function.py
@@ -39,6 +39,7 @@ from . import register, unittest
 @register( 'diagonalize', function.diagonalize, numeric.diagonalize, [(2,1,2)] )
 @register( 'multiply', function.multiply, numpy.multiply, [(3,1),(1,3)] )
 @register( 'divide', function.divide, numpy.divide, [(3,1),(1,3)] )
+@register( 'divide2', lambda a: function.asarray(a)/2, lambda a: a/2, [(3,1)] )
 @register( 'add', function.add, numpy.add, [(3,1),(1,3)] )
 @register( 'subtract', function.subtract, numpy.subtract, [(3,1),(1,3)] )
 @register( 'product2', lambda a,b: function.multiply(a,b).sum(-2), lambda a,b: (a*b).sum(-2), [(2,3,1),(1,3,2)] )


### PR DESCRIPTION
The introduction of Array.dtype triggered a problem in numpy.power, which returns an integer when both the base and the exponent are integer regardless of the sign of the exponent. The direct consequence for nutils was that expressions like function.reciprocal( 2 ) = function.power( 2, -1 ) resulted in 0. Fixed by introducing numeric.power which always returns a float array.