### PR TITLE
fix StructuredTopology.periodic with !isdim axes

### DIFF
--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -969,7 +969,8 @@ class StructuredTopology( Topology ):
 
   @property
   def periodic( self ):
-    return tuple( idim for idim, axis in enumerate(self.axes) if axis.isdim and axis.isperiodic )
+    dimaxes = ( axis for axis in self.axes if axis.isdim )
+    return tuple( idim for idim, axis in enumerate(dimaxes) if axis.isdim and axis.isperiodic )
 
   @staticmethod
   def mktransforms( axes, root, nrefine ):

--- a/tests/topology.py
+++ b/tests/topology.py
@@ -140,6 +140,19 @@ def structure2d():
     domain, geom = mesh.rectilinear( [[-1,0,1]]*3 )
     verify_interfaces( domain, geom, periodic=False )
 
+@register('2d_1_0', 2, [1], 0)
+@register('2d_0_1', 2, [0], 1)
+@register('3d_0,2_1', 3, [0,2], 1)
+def structured_prop_periodic(ndim, periodic, sdim):
+
+  bnames = 'left', 'top', 'front'
+  side = bnames[sdim]
+
+  @unittest
+  def test():
+    domain, geom = mesh.rectilinear( [2]*ndim, periodic=periodic )
+    assert list( domain.boundary[side].periodic ) == [ i if i < sdim else i-1 for i in periodic if i != sdim ]
+
 def _test_pickle_dump_load( data ):
   script = b'from nutils import *\nimport pickle, base64\npickle.loads( base64.decodebytes( b"""' \
     + base64.encodebytes( pickle.dumps( data ) ) \


### PR DESCRIPTION
The property StructuredTopology.periodic returns a list of indices of periodic
axes, where the index incorrectly refers to the list of all axes instead of
only the axes with dimension.  This causes a problem when creating a basis on
the boundary of a domain with a periodic dimension:

    domain, geom = mesh.rectilinear([2,2], periodic=[1])
    domain.boundary['left'].periodic # should return [0]
    len(domain.boundary['left'].basis('spline', degree=1)) # should return 2

Fixed in this commit.