### PR TITLE
Fix __qualname__ of MultipatchTopology.Patch

### DIFF
--- a/nutils/topology.py
+++ b/nutils/topology.py
@@ -1948,7 +1948,8 @@ class RevolutionTopology( Topology ):
 class MultipatchTopology( Topology ):
   'multipatch topology'
 
-  Patch = collections.namedtuple( 'patch', [ 'topo', 'verts', 'boundaries'] )
+  Patch = collections.namedtuple( 'Patch', [ 'topo', 'verts', 'boundaries'] )
+  Patch.__qualname__ = 'MultipatchTopology.Patch'
 
   @staticmethod
   def build_boundarydata( connectivity ):


### PR DESCRIPTION
In the current master, the `__qualname__` of `MultipatchTopology.Patch` is wrong. Namedtuples can't resolve this sort of thing when defined in a nested context so it must be done manually. (And the P must be capitalized.)