### PR TITLE
Fixes #286: $-character is parsed correctly for expressions

### DIFF
--- a/nutils/expression.py
+++ b/nutils/expression.py
@@ -906,11 +906,14 @@ class _ExpressionParser:
         tokens.append(_Token(self.expression[pos], self.expression[pos], pos))
         pos += 1
         continue
+      m = re.match(r'[%s|%s]'%tuple(self.eye_symbols), self.expression[pos:])
+      if m:
+        tokens.append(_Token('eye', m.group(0), pos))
+        pos += m.end()
+        continue
       m = re.match(r'[?]?[a-zA-Zα-ωΑ-Ω][a-zA-Zα-ωΑ-Ω0-9]*', self.expression[pos:])
       if m:
-        if m.group(0) in self.eye_symbols:
-          tokens.append(_Token('eye', m.group(0), pos))
-        elif m.group(0) in self.normal_symbols:
+        if m.group(0) in self.normal_symbols:
           tokens.append(_Token('normal', m.group(0), pos))
         else:
           tokens.append(_Token('variable', m.group(0), pos))

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -366,8 +366,23 @@ class parse(TestCase):
 
   # EYE
 
-  def test_single_eye(self): self.assert_ast('a2_i δ_ij', 'j', ('sum', ('mul', ('append_axis', v._a2, _(2)), ('eye', _(2))), _(0)))
+  def test_single_eye(self):    self.assert_ast('a2_i δ_ij', 'j', ('sum', ('mul', ('append_axis', v._a2, _(2)), ('eye', _(2))), _(0)))
+  def test_single_eye_v2(self): self.assert_ast('a2_i $_ij', 'j', ('sum', ('mul', ('append_axis', v._a2, _(2)), ('eye', _(2))), _(0)))
   def test_multiple_eye(self): self.assert_ast('δ_ij δ_jk a2_i a2_k', '',
+    ('sum',
+      ('mul',
+        ('sum',
+          ('mul',
+            ('sum',
+              ('mul',
+                ('append_axis', ('eye', _(2)), _(2)),
+                ('transpose', ('append_axis', ('eye', _(2)), _(2)), _((2,0,1)))),
+              _(1)),
+            ('append_axis', v._a2, _(2))),
+          _(0)),
+        v._a2),
+      _(0)))
+  def test_multiple_eye_v2(self): self.assert_ast('δ_ij $_jk a2_i a2_k', '',
     ('sum',
       ('mul',
         ('sum',


### PR DESCRIPTION
With this fix, then I do manage to run the example file in question, but I'm not sure if I break other things.

Instructions on how to run the complete test suite would be welcome.