### PR TITLE
fix ischeme vtk for point*tensor reference

### DIFF
--- a/nutils/element.py
+++ b/nutils/element.py
@@ -820,7 +820,10 @@ class TensorReference(Reference):
     return '{}*{}'.format(self.ref1, self.ref2)
 
   def getischeme_vtk(self):
-    if self.ref1.ndims == self.ref2.ndims == 1:
+    if self.ref1.ndims == 0:
+      assert self.ref1.nverts == 1
+      points, weights = self.ref2.getischeme_vtk()
+    elif self.ref1.ndims == self.ref2.ndims == 1:
       points = numpy.empty([2, 2, 2])
       points[...,:1] = self.ref1.vertices[:,_]
       points[0,:,1:] = self.ref2.vertices


### PR DESCRIPTION
The `getischeme_vtk` method of the `TensorReference` generates integration
points with incorrect order if `ref1` has dimension zero.  Such references
originate for example from the boundary in dimension zero of a structured
topology.  Since `ref1` has no contribution to the integration points anyhow,
this patch fixes this issue by forwarding `getischeme_vtk` to `ref2`.