### PR TITLE
use default unittest test loader in setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ except:
   from distutils.core import setup, Extension
 else:
   extra['install_requires'] = ['numpy>=1.12', 'matplotlib>=1.3', 'scipy>=0.13', 'sphinx']
+  extra['command_options'] = dict(test=dict(test_loader=('setup.py', 'unittest:TestLoader')))
 
 long_description = """
 The nutils project is a collaborative programming effort aimed at the creation


### PR DESCRIPTION
`setuptools` uses a custom unittest loader that discovers more tests than the
`unittest` builtin loader.  To make things worse, as of `setuptools` commit
dbff2e7e the custom loader breaks our `tests/test_examples.py` test suite.
This commit forces the test command of `setup.py` to use the default test
loader.