### PR TITLE
Fixlinear

### DIFF
--- a/nutils/transform.py
+++ b/nutils/transform.py
@@ -98,26 +98,21 @@ def lookup_item(chain, transforms):
   item = transforms[head] if isinstance(transforms, collections.Mapping) else transforms.index(head)
   return item, tail
 
-def linearfrom(chain, ndims):
-  if chain and ndims < chain[-1].fromdims:
-    for i in reversed(range(len(chain))):
-      if chain[i].todims == ndims:
-        chain = chain[:i]
-        break
-    else:
-      raise Exception('failed to find {}D coordinate system'.format(ndims))
+def linearfrom(chain, fromdims):
+  todims = chain[0].todims if chain else fromdims
+  while chain and fromdims < chain[-1].fromdims:
+    chain = chain[:-1]
   if not chain:
-    return numpy.eye(ndims)
+    assert todims == fromdims
+    return numpy.eye(fromdims)
   linear = numpy.eye(chain[-1].fromdims)
-  for trans in reversed(chain):
-    linear = numpy.dot(trans.linear, linear)
-    if trans.todims == trans.fromdims + 1:
-      linear = numpy.concatenate([linear, trans.ext[:,_]], axis=1)
-  n, m = linear.shape
-  if m >= ndims:
-    return linear[:,:ndims]
-  return numpy.concatenate([linear, numpy.zeros((n,ndims-m))], axis=1)
-
+  for transitem in reversed(canonical(chain)):
+    linear = numpy.dot(transitem.linear, linear)
+    if transitem.todims == transitem.fromdims + 1:
+      linear = numpy.concatenate([linear, transitem.ext[:,_]], axis=1)
+  assert linear.shape[0] == todims
+  return linear[:,:fromdims] if linear.shape[1] >= fromdims \
+    else numpy.concatenate([linear, numpy.zeros((todims, fromdims-linear.shape[1]))], axis=1)
 
 ## TRANSFORM ITEMS
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -251,6 +251,17 @@ for domtype in 'circle', 'cylinder', 'hollowcylinder':
     revolved(domtype=domtype, refined=refined)
 
 
+class refined(TestCase):
+
+  def test_boundary(self):
+    domain, geom = mesh.rectilinear([1])
+    u = domain.basis('std', degree=1).dot([0,1])
+    p, = domain.boundary['right'].sample('uniform', 1).eval(u.ngrad(geom))
+    self.assertEqual(p, 1)
+    p, = domain.refined.boundary['right'].sample('uniform', 1).eval(u.ngrad(geom))
+    self.assertEqual(p, 1)
+
+
 @parametrize
 class general(TestCase):
 


### PR DESCRIPTION
Fixes this situation:

    from nutils import *
    domain, geom = mesh.rectilinear([1])
    basis = domain.basis('std', degree=1)
    u = domain.projection(geom[0], onto=basis, geometry=geom, degree=2)
    p, = domain.refined.boundary['right'].sample('uniform', 1).eval(u.ngrad(geom))
    print(p) # resulted in 0.5, now correctly results in 1.0