### PR TITLE
fixed the _derivative helper function in solver.py

### DIFF
--- a/nutils/solver.py
+++ b/nutils/solver.py
@@ -698,7 +698,7 @@ def _derivative(residual, target, jacobian=None):
   if jacobian is None:
     jacobian = residual.derivative(target)
   if jacobian.shape != residual.shape * 2:
-    raise ValueError('expected `jacobian` with shape {} but got {}'.format(inertia.shape * 2, jacobian.shape))
+    raise ValueError('expected `jacobian` with shape {} but got {}'.format(residual.shape * 2, jacobian.shape))
   return jacobian
 
 # vim:sw=2:sts=2:et


### PR DESCRIPTION
Replaced ``inertia.shape`` by ``residual.shape`` in the _derivative helper function of the solver module.