### PR TITLE
skip attributes with leading _ in log.__getattr__

### DIFF
--- a/nutils/function.py
+++ b/nutils/function.py
@@ -492,7 +492,7 @@ class Array(Evaluable):
 
   Attributes
   ----------
-  shape : :class:`tuple` of :class:`int`\s
+  shape : :class:`tuple` of :class:`int`\\s
       The shape of this array function.
   ndim : :class:`int`
       The number of dimensions of this array array function.  Equal to
@@ -2843,7 +2843,7 @@ class Polyval(Array):
   '''
   Computes the :math:`k`-dimensional array
 
-  .. math:: j_0,\\dots,j_{k-1} \\mapsto \\sum_{\substack{i_0,\\dots,i_{n-1}\\in\mathbb{N}\\\\i_0+\\cdots+i_{n-1}\\le d}} p_0^{i_0} \\cdots p_{n-1}^{i_{n-1}} c_{j_0,\\dots,j_{k-1},i_0,\\dots,i_{n-1}},
+  .. math:: j_0,\\dots,j_{k-1} \\mapsto \\sum_{\\substack{i_0,\\dots,i_{n-1}\\in\\mathbb{N}\\\\i_0+\\cdots+i_{n-1}\\le d}} p_0^{i_0} \\cdots p_{n-1}^{i_{n-1}} c_{j_0,\\dots,j_{k-1},i_0,\\dots,i_{n-1}},
 
   where :math:`p` are the :math:`n`-dimensional local coordinates and :math:`c`
   is the argument ``coeffs`` and :math:`d` is the degree of the polynomial,
@@ -3773,7 +3773,7 @@ def bringforward(arg, axis):
 
 def jacobian(geom, ndims):
   '''
-  Return :math:`\sqrt{|J^T J|}` with :math:`J` the gradient of ``geom`` to the
+  Return :math:`\\sqrt{|J^T J|}` with :math:`J` the gradient of ``geom`` to the
   local coordinate system with ``ndims`` dimensions (``localgradient(geom,
   ndims)``).
   '''
@@ -3965,7 +3965,7 @@ def mask(arg, mask, axis=0):
 
 def J(geometry, ndims=None):
   '''
-  Return :math:`\sqrt{|J^T J|}` with :math:`J` the gradient of ``geometry`` to
+  Return :math:`\\sqrt{|J^T J|}` with :math:`J` the gradient of ``geometry`` to
   the local coordinate system with ``ndims`` dimensions (``localgradient(geom,
   ndims)``).
   '''

--- a/nutils/log.py
+++ b/nutils/log.py
@@ -19,9 +19,10 @@
 # THE SOFTWARE.
 
 """
-The log module provides print methods ``debug``, ``info``, ``user``,
-``warning``, and ``error``, in increasing order of priority. Output is sent to
-stdout as well as to an html formatted log file if so configured.
+The log module provides print methods :func:`debug`, :func:`info`,
+:func:`user`, :func:`warning`, and :func:`error`, in increasing order of
+priority. Output is sent to stdout as well as to an html formatted log file if
+so configured.
 
 This is a transitional wrapper around the external treelog module.
 """
@@ -102,18 +103,14 @@ def open(filename, mode, *, level='user', exists=None):
     f.devnull = not f
     yield f
 
-def __getattr__(name):
-  return getattr(treelog.current, name)
-
-if sys.version_info < (3,7):
-  def _factory(name):
-    def wrapper(*args, **kwargs):
-      return __getattr__(name)(*args, **kwargs)
-    wrapper.__doc__ = getattr(treelog.Log, name).__doc__
-    wrapper.__name__ = name
-    wrapper.__qualname__ = name
-    return wrapper
-  globals().update((name, _factory(name)) for name in dir(treelog.Log) if name not in globals() and callable(getattr(treelog.Log, name)))
-  del _factory
+def _factory(name):
+  def wrapper(*args, **kwargs):
+    return getattr(treelog.current, name)(*args, **kwargs)
+  wrapper.__doc__ = getattr(treelog.Log, name).__doc__
+  wrapper.__name__ = name
+  wrapper.__qualname__ = name
+  return wrapper
+globals().update((name, _factory(name)) for name in dir(treelog.Log) if not name.startswith('_') and name not in globals() and callable(getattr(treelog.Log, name)))
+del _factory
 
 # vim:sw=2:sts=2:et


### PR DESCRIPTION
This fixes Sphinx >= 2.1.0 with Python >= 3.7.  Sphinx calls
`getattr(nutils.log, name)` with names `'__module__'`, which results in
`treelog.current.__module__`, and `'__all__'`.